### PR TITLE
chore(deps): update go-advanced-admin to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/go-advanced-admin/web-echo
 go 1.16
 
 require (
-	github.com/go-advanced-admin/admin v0.1.1
+	github.com/go-advanced-admin/admin v0.1.2
 	github.com/labstack/echo/v4 v4.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-advanced-admin/admin v0.1.1 h1:QdIaow/9H1+nLFZF+f+OcOFNgAMDO4tiDHIAFENJZ7c=
-github.com/go-advanced-admin/admin v0.1.1/go.mod h1:D3CnnWIs4EEU5QjVY6fBGHd/zjtBC2FlAQ2AQvWurHU=
+github.com/go-advanced-admin/admin v0.1.2 h1:6dY8uHCph1m48SNI/zVVVe3icaWa7XzdyDHkJ03YlzA=
+github.com/go-advanced-admin/admin v0.1.2/go.mod h1:D3CnnWIs4EEU5QjVY6fBGHd/zjtBC2FlAQ2AQvWurHU=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Upgraded the go-advanced-admin module from version 0.1.1 to 0.1.2 to incorporate bug fixes and improvements from the latest release. This update aims to enhance stability and functionality within the application.