### PR TITLE
chore(issue-template): update label format in style issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/style.md
+++ b/.github/ISSUE_TEMPLATE/style.md
@@ -2,7 +2,7 @@
 name: "Stylistic Issue"
 about: Report an inconsistency or improvement related to code style or formatting.
 title: "[STYLE] Brief description of the stylistic issue"
-labels: 'style'
+labels: style
 assignees: ''
 
 ---


### PR DESCRIPTION
Updated the label format in the style issue template by removing quotes around 'style'. This change aligns with the repository's labeling convention and ensures consistency across issue templates.